### PR TITLE
Added sync for Divisional Round

### DIFF
--- a/src/Picus.Api/Mappers/GameMapper.cs
+++ b/src/Picus.Api/Mappers/GameMapper.cs
@@ -59,7 +59,7 @@ public static class GameMapper
 
         // Handle playoff weeks
         if (round == "160") return 19;  // Wild Card Round
-        if (round == "161") return 20;  // Divisional Round
+        if (round == "125") return 20;  // Divisional Round
         if (round == "162") return 21;  // Conference Championships
         if (round == "163") return 22;  // Super Bowl
 


### PR DESCRIPTION
The games from thesportdb have different numbers for their playoff rounds. This commit adds the number for the Divisional round which is 125